### PR TITLE
add husky pre-commit hook for lint and test

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+set -e
+
+pnpm lint
+pnpm test

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build": "tsc",
     "prepublishOnly": "pnpm build",
     "test": "vitest run",
-    "lint": "eslint 'src/**/*.{ts,tsx}' --max-warnings=0"
+    "lint": "eslint 'src/**/*.{ts,tsx}' --max-warnings=0",
+    "prepare": "husky"
   },
   "repository": {
     "type": "git",
@@ -50,6 +51,7 @@
     "@typescript-eslint/parser": "^8.29.1",
     "eslint": "^9.24.0",
     "eslint-plugin-import": "^2.31.0",
+    "husky": "^9.1.7",
     "jsdom": "^29.1.1",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.29.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.31.0
         version: 2.31.0(@typescript-eslint/parser@8.29.1(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0)
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -867,6 +870,11 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2534,6 +2542,8 @@ snapshots:
       '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  husky@9.1.7: {}
 
   ignore@5.3.2: {}
 


### PR DESCRIPTION
## Summary

Adds a husky pre-commit hook that runs `pnpm lint` and `pnpm test` before every commit, so style and test regressions are caught locally rather than in CI/review.

## What's included

- `husky@^9.1.7` as a devDependency
- `prepare: "husky"` lifecycle script (installs the hook on `pnpm install`)
- `.husky/pre-commit` running:
  ```sh
  set -e

  pnpm lint
  pnpm test
  ```
  `set -e` ensures a lint failure aborts the commit even though a later test step would pass.

## Why this shape (vs. the generic husky + lint-staged + Prettier setup)

- **No Prettier.** The repo styles with ESLint (single quotes); Prettier's defaults (`singleQuote: false`) would reformat the whole codebase.
- **No lint-staged.** ESLint here is type-aware (`parserOptions.project`) and tsconfig `include` is `["src"]`, so linting arbitrary staged files (tests, scripts) throws "file not included in project". The hook calls the repo's correctly-scoped `pnpm lint` instead.

## Verification

The commit that introduces the hook ran through it — `pnpm lint` clean, `pnpm test` 15/15 passing.