### PR TITLE
Fix npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish package to GitHub Packages
+name: Publish package to npm
 
 on:
   release:
@@ -14,16 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: pnpm install
-      - run: pnpm publish --access public
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm publish --access public --no-git-checks
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Update the publish workflow name to reflect npm publishing
- Use `pnpm/action-setup@v6`, which reads the repo `packageManager` field
- Install with `pnpm install --frozen-lockfile` so CI uses the committed lockfile
- Publish with `--no-git-checks` to avoid CI workspace dirtiness blocking publish

## Context
The `v0.1.2` release workflow failed because CI used `pnpm/action-setup@v2` with pnpm 8. That ignored the current lockfile, left the checkout dirty after install, and caused `pnpm publish` to fail before publishing to npm.

## Validation
- `pnpm install --frozen-lockfile`
- pre-commit hook ran `eslint 'src/**/*.{ts,tsx}' --max-warnings=0`
- pre-commit hook ran `vitest run`
