### PR TITLE
Update publish workflow runtime

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,13 +12,13 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Update publish workflow actions to current major versions
- Run the publish workflow on Node 24

## Validation
- `git diff --check .github/workflows/publish.yml`
- pre-commit hook ran `eslint 'src/**/*.{ts,tsx}' --max-warnings=0`
- pre-commit hook ran `vitest run`
